### PR TITLE
add explicit switches for default and override configs

### DIFF
--- a/run.py
+++ b/run.py
@@ -8,8 +8,10 @@ warnings.filterwarnings("ignore", category=UserWarning, module="langsmith")
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Process some integers.")
-    parser.add_argument('--config_path', type=str, default='config/config_default.yml',
-                        help="The configuration diff file path.")
+    parser.add_argument('--override_config_path', type=str, default='config/config_default.yml',
+                        help="The file path to the override configuration diff.")
+    parser.add_argument('--default_config_path', type=str, default='config/config_default.yml',
+                        help="The file path to the default configuration to be overridden.")
     parser.add_argument('--output_path', type=str, required=True, help="Path to the output file.")
     parser.add_argument('--dataset', type=str, default='latest', help="The dataset name. "
                                                                       "If 'latest', the latest dataset will be loaded.")
@@ -20,7 +22,7 @@ def parse_args():
 
 def main():
     args = parse_args()
-    config = override_config(args.config_path)
+    config = override_config(args.override_config_path, args.default_config_path)
     # loading the simulator executor with the environment
     executor = SimulatorExecutor(config, args.output_path)
     # Loading the dataset default is latest, if you want to load a specific dataset, pass the path

--- a/simulator/utils/file_reading.py
+++ b/simulator/utils/file_reading.py
@@ -87,7 +87,7 @@ def override_llm(config, llm_config):
     return config
 
 
-def override_config(override_config_file, config_file='config/config_default.yml'):
+def override_config(override_config_file, config_file):
     """
     Override the default configuration file with the override configuration file
     :param config_file: The default configuration file


### PR DESCRIPTION
I found it convenient to add a switch for the default configuration, so that I can customize basic settings and keep override configs light. I added explicit ```override_config_path``` and ```default_config_path``` for my clarity.