### PR TITLE
fix(parallelism): correct timeout error field and init usage counter

### DIFF
--- a/simulator/utils/parallelism.py
+++ b/simulator/utils/parallelism.py
@@ -36,6 +36,7 @@ def batch_invoke(llm_function, inputs: list[Any], num_workers: int, callbacks: l
                 error = 'Error while running: ' + str(e)
                 track_event(ExceptionEvent(exception_type=type(e).__name__,
                                    error_message=error))
+            accumulate_usage = 0
             for cb in CB:
                 accumulate_usage = cb.total_cost
         pbar.update(1)  # Update the progress bar
@@ -78,6 +79,7 @@ async def batch_ainvoke(llm_async_function, inputs: list[Any], num_workers: int,
                 error = 'Error while running: ' + str(e)
                 track_event(ExceptionEvent(exception_type=type(e).__name__,
                                    error_message=error))
+            accumulate_usage = 0
             for cb in CB:
                 accumulate_usage = cb.total_cost
         return {'index': i, 'result': result, 'usage': accumulate_usage, 'error': error}
@@ -95,7 +97,7 @@ async def batch_ainvoke(llm_async_function, inputs: list[Any], num_workers: int,
                 track_event(ExceptionEvent(exception_type=type(e).__name__,
                                    error_message=error_message))
                 return {'index': func_input[0], 'result': None, 'usage': 0,
-                        'error': 'error_message'}  # Return None or any appropriate value for a failed task
+                        'error': error_message}  # Return None or any appropriate value for a failed task
 
     # Create tasks
     tasks = [task_runner(func_input) for func_input in sample_generator()]


### PR DESCRIPTION
### What
`simulator/utils/parallelism.py` had two bugs:

1. **Wrong timeout error.** `batch_ainvoke`'s timeout handler returned `{'error': 'error_message'}` - the **literal string**, not the `error_message` variable (`'Timeout'`) - so a timed-out task surfaced a nonsensical error string in a framework whose job is agent diagnosis.
2. **`accumulate_usage` UnboundLocalError.** It was only assigned inside `for cb in CB:`, so with an empty `callbacks` list both `batch_invoke` and `batch_ainvoke` raised `UnboundLocalError` on the `'usage'` field.

### Fix
Return the `error_message` variable on timeout, and initialise `accumulate_usage = 0` before the callback loop in both functions.
